### PR TITLE
Regnerf (old)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #.idea/
 
 # Experiments and outputs
-outputs/
+outputs
 exports/
 renders/
 # tensorboard log files

--- a/docs/nerfology/methods/index.md
+++ b/docs/nerfology/methods/index.md
@@ -33,6 +33,7 @@ The following methods are supported in nerfstudio:
     Mip-NeRF<mipnerf.md>
     NeRF<nerf.md>
     Nerfacto<nerfacto.md>
+    RegNeRF<regnerf.md>
     Tetra-NeRF<tetranerf.md>
     TensoRF<tensorf.md>
 ```

--- a/docs/nerfology/methods/regnerf.md
+++ b/docs/nerfology/methods/regnerf.md
@@ -47,7 +47,18 @@ To create a loss function, these steps are followed:
 
 ### Color Likelihood
 
-TODO
+This aims to improve RGB color accuracy from unobserved viewpoints with a
+measure of how likely a set of colors is to appear. Using the same patches as
+above (Depth Smoothness Loss), the RGB image rendered from those viewpoints are
+compared to "diverse natural images", incentivizing higher probability patches
+(through the loss function).
+
+A separate RealNVP model is trained on the "diverse natural images", learning
+the likelihood of any 8x8 patch of pixels appearing. Renders from the patch
+viewpoints are passed through, and a negative log likelihood loss is applied.
+
+In both the official and this (CognitiveStudio) implementation, Color Likelihood
+loss is omitted.
 
 ### Sample Space Annealing
 

--- a/docs/nerfology/methods/regnerf.md
+++ b/docs/nerfology/methods/regnerf.md
@@ -1,0 +1,58 @@
+# RegNeRF
+
+<h4>Regularizing Neural Radiance Fields for View Synthesis from Sparse Inputs</h4>
+
+```{button-link} https://github.com/google-research/google-research/tree/master/regnerf
+:color: primary
+:outline:
+Code
+```
+
+```{button-link} https://arxiv.org/abs/2112.00724.pdf
+:color: primary
+:outline:
+Paper
+```
+
+## Running the Model
+
+```bash
+ns-train regnerf
+```
+
+## Method
+
+RegNeRF regularizes training to learn sparse (few input views) scenes better.
+Three additional methods are added to the training process.
+
+### Depth Smoothness Loss
+
+One observation in the RegNeRF paper is that problems in sparse scenes usually
+arise from messy geometry. While ground truth input views are learned well, the
+underlying geometry is not "3D consistent", leading to messy reconstructions of
+other views.
+
+To address this, RegNeRF penalizes geometry that is not smooth, assuming that
+"piece-wise smooth" structures are more common.
+
+To create a loss function, these steps are followed:
+
+- A number of "unobserved viewpoints" are randomly sampled from all possible
+  views before training starts.
+- At each training step:
+  - A batch of unobserved viewpoints are selected.
+  - The NeRF renders a patch (8x8 grid of pixels) from this viewpoint.
+  - The loss is how "unsmooth" the depth map of the patch is, computed with the
+    MSE of neighboring pixels.
+
+### Color Likelihood
+
+TODO
+
+### Sample Space Annealing
+
+Similar to depth smoothness, this aims to create a "3D consistent"
+reconstruction.
+
+To prevent divergence at the beginning of training, the near and far planes of
+each ray are brought close together, and gradually expanded.

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -620,6 +620,8 @@ method_configs["regnerf"] = TrainerConfig(
             "scheduler": None,
         }
     },
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
+    vis="viewer+wandb",
 )
 
 

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -62,6 +62,7 @@ from nerfstudio.models.nerfplayer_nerfacto import NerfplayerNerfactoModelConfig
 from nerfstudio.models.nerfplayer_ngp import NerfplayerNGPModelConfig
 from nerfstudio.models.neus import NeuSModelConfig
 from nerfstudio.models.neus_facto import NeuSFactoModelConfig
+from nerfstudio.models.regnerf import RegNerfModel
 from nerfstudio.models.semantic_nerfw import SemanticNerfWModelConfig
 from nerfstudio.models.tensorf import TensoRFModelConfig
 from nerfstudio.models.vanilla_nerf import NeRFModel, VanillaModelConfig
@@ -86,6 +87,7 @@ descriptions = {
     "nerfplayer-ngp": "NeRFPlayer with InstantNGP backbone.",
     "neus": "Implementation of NeuS. (slow)",
     "neus-facto": "Implementation of NeuS-Facto. (slow)",
+    "regnerf": "Implementation of RegNeRF (regularized with geometry and color).",
 }
 
 method_configs["nerfacto"] = TrainerConfig(
@@ -120,6 +122,7 @@ method_configs["nerfacto"] = TrainerConfig(
     viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
     vis="viewer",
 )
+
 method_configs["nerfacto-big"] = TrainerConfig(
     method_name="nerfacto",
     steps_per_eval_batch=500,
@@ -592,6 +595,26 @@ method_configs["neus-facto"] = TrainerConfig(
     },
     viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
     vis="viewer",
+)
+
+method_configs["regnerf"] = TrainerConfig(
+    method_name="regnerf",
+    pipeline=VanillaPipelineConfig(
+        datamanager=VanillaDataManagerConfig(dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=1024),
+        model=VanillaModelConfig(
+            _target=RegNerfModel,
+            loss_coefficients={"rgb_loss_coarse": 0.1, "rgb_loss_fine": 1.0},
+            num_coarse_samples=128,
+            num_importance_samples=128,
+            eval_num_rays_per_chunk=1024,
+        ),
+    ),
+    optimizers={
+        "fields": {
+            "optimizer": RAdamOptimizerConfig(lr=5e-4, eps=1e-08),
+            "scheduler": None,
+        }
+    },
 )
 
 

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -30,6 +30,7 @@ from nerfstudio.data.datamanagers.base_datamanager import (
     VanillaDataManager,
     VanillaDataManagerConfig,
 )
+from nerfstudio.data.datamanagers.regnerf_datamanager import RegNerfDataManagerConfig
 from nerfstudio.data.dataparsers.blender_dataparser import BlenderDataParserConfig
 from nerfstudio.data.dataparsers.dnerf_dataparser import DNeRFDataParserConfig
 from nerfstudio.data.dataparsers.dycheck_dataparser import DycheckDataParserConfig
@@ -603,7 +604,7 @@ method_configs["neus-facto"] = TrainerConfig(
 method_configs["regnerf"] = TrainerConfig(
     method_name="regnerf",
     pipeline=RegNerfPipelineConfig(
-        datamanager=VanillaDataManagerConfig(dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=1024),
+        datamanager=RegNerfDataManagerConfig(dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=1024),
         model=RegNerfModelConfig(
             _target=RegNerfModel,
             loss_coefficients={

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -62,7 +62,7 @@ from nerfstudio.models.nerfplayer_nerfacto import NerfplayerNerfactoModelConfig
 from nerfstudio.models.nerfplayer_ngp import NerfplayerNGPModelConfig
 from nerfstudio.models.neus import NeuSModelConfig
 from nerfstudio.models.neus_facto import NeuSFactoModelConfig
-from nerfstudio.models.regnerf import RegNerfModel
+from nerfstudio.models.regnerf import RegNerfModel, RegNerfModelConfig
 from nerfstudio.models.semantic_nerfw import SemanticNerfWModelConfig
 from nerfstudio.models.tensorf import TensoRFModelConfig
 from nerfstudio.models.vanilla_nerf import NeRFModel, VanillaModelConfig
@@ -601,9 +601,14 @@ method_configs["regnerf"] = TrainerConfig(
     method_name="regnerf",
     pipeline=VanillaPipelineConfig(
         datamanager=VanillaDataManagerConfig(dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=1024),
-        model=VanillaModelConfig(
+        model=RegNerfModelConfig(
             _target=RegNerfModel,
-            loss_coefficients={"rgb_loss_coarse": 0.1, "rgb_loss_fine": 1.0},
+            loss_coefficients={
+                "rgb_loss_coarse": 0.1,
+                "rgb_loss_fine": 1.0,
+                "depth_smoothness": 1.0,
+                "color_likelihood": 1.0,
+            },
             num_coarse_samples=128,
             num_importance_samples=128,
             eval_num_rays_per_chunk=1024,

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -310,6 +310,8 @@ method_configs["mipnerf"] = TrainerConfig(
             "scheduler": None,
         }
     },
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 12),
+    vis="viewer+wandb",
 )
 
 method_configs["semantic-nerfw"] = TrainerConfig(

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -68,6 +68,7 @@ from nerfstudio.models.tensorf import TensoRFModelConfig
 from nerfstudio.models.vanilla_nerf import NeRFModel, VanillaModelConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
 from nerfstudio.pipelines.dynamic_batch import DynamicBatchPipelineConfig
+from nerfstudio.pipelines.regnerf_pipeline import RegNerfPipeline, RegNerfPipelineConfig
 from nerfstudio.plugins.registry import discover_methods
 
 method_configs: Dict[str, TrainerConfig] = {}
@@ -601,7 +602,7 @@ method_configs["neus-facto"] = TrainerConfig(
 
 method_configs["regnerf"] = TrainerConfig(
     method_name="regnerf",
-    pipeline=VanillaPipelineConfig(
+    pipeline=RegNerfPipelineConfig(
         datamanager=VanillaDataManagerConfig(dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=1024),
         model=RegNerfModelConfig(
             _target=RegNerfModel,

--- a/nerfstudio/data/datamanagers/regnerf_datamanager.py
+++ b/nerfstudio/data/datamanagers/regnerf_datamanager.py
@@ -1,0 +1,63 @@
+# Copyright 2022 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RegNerf datamanager.
+Author: Patrick Huang
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Generic, Tuple, Type
+
+from nerfstudio.cameras.rays import RayBundle
+from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManager, VanillaDataManagerConfig, TDataset
+
+
+@dataclass
+class RegNerfDataManagerConfig(VanillaDataManagerConfig):
+    """Data manager for RegNerf."""
+
+    _target: Type = field(default_factory=lambda: RegNerfDataManager)
+    """Target class to instantiate."""
+
+
+class RegNerfDataManager(VanillaDataManager, Generic[TDataset]):
+    """
+    Data manager for RegNerf.
+
+    Extended functionalities:
+    - Generates random poses and rays (TODO).
+    - Performs sample space annealing.
+    """
+
+    def next_train(self, step: int) -> Tuple[RayBundle, Dict]:
+        """
+        Returns the next batch of data from the train dataloader.
+        Also does sample space annealing by changing RayBundle nears and fars.
+        """
+        # This is copied from super class.
+        self.train_count += 1
+        image_batch = next(self.iter_train_image_dataloader)
+        assert self.train_pixel_sampler is not None
+        assert isinstance(image_batch, dict)
+        batch = self.train_pixel_sampler.sample(image_batch)
+        ray_indices = batch["indices"]
+        ray_bundle = self.train_ray_generator(ray_indices)
+
+        # Sample space annealing.
+        # TODO
+
+        return ray_bundle, batch

--- a/nerfstudio/data/datamanagers/regnerf_datamanager.py
+++ b/nerfstudio/data/datamanagers/regnerf_datamanager.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Generic, Tuple, Type
 
+import torch
+
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManager, VanillaDataManagerConfig, TDataset
 
@@ -43,21 +45,4 @@ class RegNerfDataManager(VanillaDataManager, Generic[TDataset]):
     - Performs sample space annealing.
     """
 
-    def next_train(self, step: int) -> Tuple[RayBundle, Dict]:
-        """
-        Returns the next batch of data from the train dataloader.
-        Also does sample space annealing by changing RayBundle nears and fars.
-        """
-        # This is copied from super class.
-        self.train_count += 1
-        image_batch = next(self.iter_train_image_dataloader)
-        assert self.train_pixel_sampler is not None
-        assert isinstance(image_batch, dict)
-        batch = self.train_pixel_sampler.sample(image_batch)
-        ray_indices = batch["indices"]
-        ray_bundle = self.train_ray_generator(ray_indices)
-
-        # Sample space annealing.
-        # TODO
-
-        return ray_bundle, batch
+    config: RegNerfDataManagerConfig

--- a/nerfstudio/models/regnerf.py
+++ b/nerfstudio/models/regnerf.py
@@ -76,9 +76,7 @@ class RegNerfModelConfig(VanillaModelConfig):
     """Whether to only sample random poses from upper hemisphere."""
     randpose_s_patch: int = 8
     """Random pose patch size."""
-    #randpose_focal: float = 1000
-    #"""Random pose patch focal length."""
-    randpose_bs: int = 32
+    randpose_bs: int = 16
     """Batch size (number of poses) per step for regularization."""
 
 
@@ -151,8 +149,8 @@ class RegNerfModel(Model):
         focal = self.focal
 
         x, y = torch.meshgrid(
-            torch.linspace(-1, 1, s_patch),
-            torch.linspace(-1, 1, s_patch),
+            torch.linspace(-1, 1, s_patch) * s_patch,
+            torch.linspace(-1, 1, s_patch) * s_patch,
             indexing="xy",
         )
         # Shape (s_patch, s_patch, 3)

--- a/nerfstudio/models/regnerf.py
+++ b/nerfstudio/models/regnerf.py
@@ -1,0 +1,201 @@
+# Copyright 2022 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Implementation of RegNeRF.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import torch
+from torch.nn import Parameter
+from torchmetrics import PeakSignalNoiseRatio
+from torchmetrics.functional import structural_similarity_index_measure
+from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
+
+from nerfstudio.cameras.rays import RayBundle
+from nerfstudio.field_components.encodings import NeRFEncoding
+from nerfstudio.field_components.field_heads import FieldHeadNames
+from nerfstudio.fields.vanilla_nerf_field import NeRFField
+from nerfstudio.model_components.losses import MSELoss
+from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
+from nerfstudio.model_components.renderers import (
+    AccumulationRenderer,
+    DepthRenderer,
+    RGBRenderer,
+)
+from nerfstudio.models.base_model import Model
+from nerfstudio.models.vanilla_nerf import VanillaModelConfig
+from nerfstudio.utils import colormaps, colors, misc
+
+
+class RegNerfModel(Model):
+    """RegNeRF model
+
+    Args:
+        config: RegNerf configuration to instantiate model
+    """
+
+    config: VanillaModelConfig
+
+    def __init__(
+        self,
+        config: VanillaModelConfig,
+        **kwargs,
+    ) -> None:
+        self.field = None
+        assert config.collider_params is not None, "RegNeRF model requires bounding box collider parameters."
+        super().__init__(config=config, **kwargs)
+        assert self.config.collider_params is not None, "RegNeRF requires collider parameters to be set."
+
+    def populate_modules(self):
+        """Set the fields and modules"""
+        super().populate_modules()
+
+        # setting up fields
+        position_encoding = NeRFEncoding(
+            in_dim=3, num_frequencies=16, min_freq_exp=0.0, max_freq_exp=16.0, include_input=True
+        )
+        direction_encoding = NeRFEncoding(
+            in_dim=3, num_frequencies=4, min_freq_exp=0.0, max_freq_exp=4.0, include_input=True
+        )
+
+        self.field = NeRFField(
+            position_encoding=position_encoding, direction_encoding=direction_encoding, use_integrated_encoding=True
+        )
+
+        # samplers
+        self.sampler_uniform = UniformSampler(num_samples=self.config.num_coarse_samples)
+        self.sampler_pdf = PDFSampler(num_samples=self.config.num_importance_samples, include_original=False)
+
+        # renderers
+        self.renderer_rgb = RGBRenderer(background_color=colors.WHITE)
+        self.renderer_accumulation = AccumulationRenderer()
+        self.renderer_depth = DepthRenderer()
+
+        # losses
+        self.rgb_loss = MSELoss()
+
+        # metrics
+        self.psnr = PeakSignalNoiseRatio(data_range=1.0)
+        self.ssim = structural_similarity_index_measure
+        self.lpips = LearnedPerceptualImagePatchSimilarity(normalize=True)
+
+    def get_param_groups(self) -> Dict[str, List[Parameter]]:
+        param_groups = {}
+        if self.field is None:
+            raise ValueError("populate_fields() must be called before get_param_groups")
+        param_groups["fields"] = list(self.field.parameters())
+        return param_groups
+
+    def get_outputs(self, ray_bundle: RayBundle):
+        print("Regnerf get outputs")
+        if self.field is None:
+            raise ValueError("populate_fields() must be called before get_outputs")
+
+        # uniform sampling
+        ray_samples_uniform = self.sampler_uniform(ray_bundle)
+
+        # First pass:
+        field_outputs_coarse = self.field.forward(ray_samples_uniform)
+        weights_coarse = ray_samples_uniform.get_weights(field_outputs_coarse[FieldHeadNames.DENSITY])
+        rgb_coarse = self.renderer_rgb(
+            rgb=field_outputs_coarse[FieldHeadNames.RGB],
+            weights=weights_coarse,
+        )
+        accumulation_coarse = self.renderer_accumulation(weights_coarse)
+        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform)
+
+        # pdf sampling
+        ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_coarse)
+
+        # Second pass:
+        field_outputs_fine = self.field.forward(ray_samples_pdf)
+        weights_fine = ray_samples_pdf.get_weights(field_outputs_fine[FieldHeadNames.DENSITY])
+        rgb_fine = self.renderer_rgb(
+            rgb=field_outputs_fine[FieldHeadNames.RGB],
+            weights=weights_fine,
+        )
+        accumulation_fine = self.renderer_accumulation(weights_fine)
+        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf)
+
+        outputs = {
+            "rgb_coarse": rgb_coarse,
+            "rgb_fine": rgb_fine,
+            "accumulation_coarse": accumulation_coarse,
+            "accumulation_fine": accumulation_fine,
+            "depth_coarse": depth_coarse,
+            "depth_fine": depth_fine,
+        }
+        return outputs
+
+    def get_loss_dict(self, outputs, batch, metrics_dict=None):
+        image = batch["image"].to(self.device)
+        rgb_loss_coarse = self.rgb_loss(image, outputs["rgb_coarse"])
+        rgb_loss_fine = self.rgb_loss(image, outputs["rgb_fine"])
+        loss_dict = {"rgb_loss_coarse": rgb_loss_coarse, "rgb_loss_fine": rgb_loss_fine}
+        loss_dict = misc.scale_dict(loss_dict, self.config.loss_coefficients)
+        return loss_dict
+
+    def get_image_metrics_and_images(
+        self, outputs: Dict[str, torch.Tensor], batch: Dict[str, torch.Tensor]
+    ) -> Tuple[Dict[str, float], Dict[str, torch.Tensor]]:
+        assert self.config.collider_params is not None, "RegNeRF requires collider parameters to be set."
+        image = batch["image"].to(outputs["rgb_coarse"].device)
+        rgb_coarse = outputs["rgb_coarse"]
+        rgb_fine = outputs["rgb_fine"]
+        acc_coarse = colormaps.apply_colormap(outputs["accumulation_coarse"])
+        acc_fine = colormaps.apply_colormap(outputs["accumulation_fine"])
+
+        assert self.config.collider_params is not None
+        depth_coarse = colormaps.apply_depth_colormap(
+            outputs["depth_coarse"],
+            accumulation=outputs["accumulation_coarse"],
+            near_plane=self.config.collider_params["near_plane"],
+            far_plane=self.config.collider_params["far_plane"],
+        )
+        depth_fine = colormaps.apply_depth_colormap(
+            outputs["depth_fine"],
+            accumulation=outputs["accumulation_fine"],
+            near_plane=self.config.collider_params["near_plane"],
+            far_plane=self.config.collider_params["far_plane"],
+        )
+
+        combined_rgb = torch.cat([image, rgb_coarse, rgb_fine], dim=1)
+        combined_acc = torch.cat([acc_coarse, acc_fine], dim=1)
+        combined_depth = torch.cat([depth_coarse, depth_fine], dim=1)
+
+        # Switch images from [H, W, C] to [1, C, H, W] for metrics computations
+        image = torch.moveaxis(image, -1, 0)[None, ...]
+        rgb_coarse = torch.moveaxis(rgb_coarse, -1, 0)[None, ...]
+        rgb_fine = torch.moveaxis(rgb_fine, -1, 0)[None, ...]
+        rgb_coarse = torch.clip(rgb_coarse, min=0, max=1)
+        rgb_fine = torch.clip(rgb_fine, min=0, max=1)
+
+        coarse_psnr = self.psnr(image, rgb_coarse)
+        fine_psnr = self.psnr(image, rgb_fine)
+        fine_ssim = self.ssim(image, rgb_fine)
+        fine_lpips = self.lpips(image, rgb_fine)
+
+        assert isinstance(fine_ssim, torch.Tensor)
+        metrics_dict = {
+            "psnr": float(fine_psnr.item()),
+            "coarse_psnr": float(coarse_psnr.item()),
+            "fine_psnr": float(fine_psnr.item()),
+            "fine_ssim": float(fine_ssim.item()),
+            "fine_lpips": float(fine_lpips.item()),
+        }
+        images_dict = {"img": combined_rgb, "accumulation": combined_acc, "depth": combined_depth}
+        return metrics_dict, images_dict

--- a/nerfstudio/models/regnerf.py
+++ b/nerfstudio/models/regnerf.py
@@ -36,11 +36,8 @@ from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
 from nerfstudio.model_components.losses import MSELoss
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-)
+from nerfstudio.model_components.renderers import (AccumulationRenderer,
+                                                   DepthRenderer, RGBRenderer)
 from nerfstudio.model_components.scene_colliders import AnnealedNearFarCollider
 from nerfstudio.models.base_model import Model
 from nerfstudio.models.vanilla_nerf import VanillaModelConfig
@@ -64,7 +61,7 @@ class RegNerfModelConfig(VanillaModelConfig):
         "far_plane": 6.0,
         "anneal_midfac": 0.5,
         "anneal_start": 0.5,
-        "anneal_duration": 200,
+        "anneal_duration": 2000,
     })
     """This is for AnnealedNearFarCollider"""
 
@@ -441,8 +438,8 @@ def plot_patch_rays(patch_rays: RayBundle):
     """
     3D matplotlib of a few patches.
     """
-    import numpy as np
     import matplotlib.pyplot as plt
+    import numpy as np
     from mpl_toolkits.mplot3d import art3d
 
     fig = plt.figure()

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -250,6 +250,7 @@ class VanillaPipeline(Pipeline):
         assert self.datamanager.train_dataset is not None, "Missing input dataset"
 
         self._model = config.model.setup(
+            focal=self.datamanager.train_dataparser_outputs.cameras.fx,
             scene_box=self.datamanager.train_dataset.scene_box,
             num_train_data=len(self.datamanager.train_dataset),
             metadata=self.datamanager.train_dataset.metadata,

--- a/nerfstudio/pipelines/regnerf_pipeline.py
+++ b/nerfstudio/pipelines/regnerf_pipeline.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Type
 
+from nerfstudio.data.datamanagers.regnerf_datamanager import RegNerfDataManagerConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipeline, VanillaPipelineConfig
 
 
@@ -29,6 +30,8 @@ class RegNerfPipelineConfig(VanillaPipelineConfig):
     """Config for RegNerf pipeline."""
 
     _target: Type = field(default_factory=lambda: RegNerfPipeline)
+    """Overrides superclass."""
+    datamanager: RegNerfDataManagerConfig = RegNerfDataManagerConfig()
     """Overrides superclass."""
 
 

--- a/nerfstudio/pipelines/regnerf_pipeline.py
+++ b/nerfstudio/pipelines/regnerf_pipeline.py
@@ -1,0 +1,38 @@
+# Copyright 2022 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abstracts for the Pipeline class.
+Author: Patrick Huang
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Type
+
+from nerfstudio.pipelines.base_pipeline import VanillaPipeline, VanillaPipelineConfig
+
+
+@dataclass
+class RegNerfPipelineConfig(VanillaPipelineConfig):
+    """Config for RegNerf pipeline."""
+
+    _target: Type = field(default_factory=lambda: RegNerfPipeline)
+    """Overrides superclass."""
+
+
+class RegNerfPipeline(VanillaPipeline):
+    """
+    Pipeline for RegNerf.
+    """

--- a/nerfstudio/pipelines/regnerf_pipeline.py
+++ b/nerfstudio/pipelines/regnerf_pipeline.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Type
 
-from nerfstudio.data.datamanagers.regnerf_datamanager import RegNerfDataManagerConfig
+import torch
+
+from nerfstudio.data.datamanagers.regnerf_datamanager import RegNerfDataManager, RegNerfDataManagerConfig
+from nerfstudio.models.regnerf import RegNerfModel
 from nerfstudio.pipelines.base_pipeline import VanillaPipeline, VanillaPipelineConfig
 
 
@@ -39,3 +42,35 @@ class RegNerfPipeline(VanillaPipeline):
     """
     Pipeline for RegNerf.
     """
+
+    datamanager: RegNerfDataManager
+    model: RegNerfModel
+
+    def get_train_loss_dict(self, step: int):
+        """
+        Overrides super class.
+        In addition to superclass functionality, adds `anneal_fac` to `loss_dict`.
+        Passes the ``step`` argument to model.
+        """
+        ray_bundle, batch = self.datamanager.next_train(step)
+        model_outputs = self._model(ray_bundle, step)  # train distributed data parallel model if world_size > 1
+        metrics_dict = self.model.get_metrics_dict(model_outputs, batch)
+
+        if self.config.datamanager.camera_optimizer is not None:
+            camera_opt_param_group = self.config.datamanager.camera_optimizer.param_group
+            if camera_opt_param_group in self.datamanager.get_param_groups():
+                # Report the camera optimization metrics
+                metrics_dict["camera_opt_translation"] = (
+                    self.datamanager.get_param_groups()[camera_opt_param_group][0].data[:, :3].norm()
+                )
+                metrics_dict["camera_opt_rotation"] = (
+                    self.datamanager.get_param_groups()[camera_opt_param_group][0].data[:, 3:].norm()
+                )
+
+        loss_dict = self.model.get_loss_dict(model_outputs, batch, metrics_dict, step)
+
+        # Add anneal fac to metrics.
+        anneal_fac = self.model.collider.get_anneal_fac(step)
+        loss_dict["anneal_fac"] = torch.tensor(anneal_fac)
+
+        return model_outputs, loss_dict, metrics_dict

--- a/nerfstudio/scripts/train.py
+++ b/nerfstudio/scripts/train.py
@@ -45,11 +45,6 @@ subcommand:
 
 from __future__ import annotations
 
-import os
-import sys
-root = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(1, os.path.abspath(os.path.join(root, "..", "..")))
-
 import random
 import socket
 import traceback

--- a/nerfstudio/scripts/train.py
+++ b/nerfstudio/scripts/train.py
@@ -45,6 +45,11 @@ subcommand:
 
 from __future__ import annotations
 
+import os
+import sys
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(1, os.path.abspath(os.path.join(root, "..", "..")))
+
 import random
 import socket
 import traceback


### PR DESCRIPTION
**What**
Implemented [RegNerf](https://arxiv.org/abs/2112.00724.pdf) and docs.
Color likelihood loss was **omitted**, like in the official implementation.

**Qualitative results**
Tested on Blender scenes (hot dog, lego) with only a few (3 to 6) training images.
Qualitative results agree with paper: New views are adequate, similar to Figure 1 of paper.

**Quantitative results**
Evaluation image metrics (PSNR, SSIM, etc.): RegNerf performed almost identically to Nerfstudio's MipNerf and VanillaNerf.
This is possibly due to some difference between Nerfstudio's vanilla nerf and what the RegNerf authors used.
The RegNerf paper shows many examples where vanilla nerf completely fails on small changes in view (Figure 1).
However, in Nerfstudio, the vanilla nerf doesn't have that problem.
RegNerf was made to fix that very problem --- the degenerate results from vanilla nerf.
Because that doesn't exist in Nerfstudio, there is no noticeable improvement.